### PR TITLE
Allow namespaces to have finalizers

### DIFF
--- a/lifecycle/object.go
+++ b/lifecycle/object.go
@@ -171,10 +171,6 @@ func (o *objectLifecycleAdapter) addFinalizer(obj runtime.Object) (runtime.Objec
 		return nil, err
 	}
 
-	if o.objectClient.GroupVersionKind().Kind == "Namespace" {
-		return obj, nil
-	}
-
 	if slice.ContainsString(metadata.GetFinalizers(), o.constructFinalizerKey()) {
 		return obj, nil
 	}


### PR DESCRIPTION
Now the we are properly formatting finalizer names, they can
successfully be added to namespaces. This has is no longer needed.