### PR TITLE
Add IsConflict to httperror

### DIFF
--- a/httperror/error.go
+++ b/httperror/error.go
@@ -103,3 +103,11 @@ func IsAPIError(err error) bool {
 	_, ok := err.(*APIError)
 	return ok
 }
+
+func IsConflict(err error) bool {
+	if apiError, ok := err.(*APIError); ok {
+		return apiError.code.Status == 409
+	}
+
+	return false
+}


### PR DESCRIPTION
Add an IsConflict function to httperror package.  The purpose of this
change is to allow the testing of APIErrors in a controlled and
centralized way.

Supports functionality in issue:
https://github.com/rancher/rancher/issues/11378

Dependency of:
https://github.com/rancher/rancher/pull/12010