### PR TITLE
Fix logic for setting annotation based fields

### DIFF
--- a/types/convert/merge/merge.go
+++ b/types/convert/merge/merge.go
@@ -40,10 +40,14 @@ func APIUpdateMerge(schema *types.Schema, schemas *types.Schemas, dest, src map[
 }
 
 func isProtected(k string) bool {
-	if !strings.Contains(k, "cattle.io/") || strings.HasPrefix(k, "field.cattle.io/") {
+	if !strings.Contains(k, "cattle.io/") || (isField(k) && k != "field.cattle.io/creatorId") {
 		return false
 	}
 	return true
+}
+
+func isField(k string) bool {
+	return strings.HasPrefix(k, "field.cattle.io/")
 }
 
 func mergeProtected(dest, src map[string]interface{}) map[string]interface{} {
@@ -61,11 +65,11 @@ func mergeProtected(dest, src map[string]interface{}) map[string]interface{} {
 	}
 
 	for k := range dest {
-		if isProtected(k) {
+		if isProtected(k) || isField(k) {
 			continue
 		}
 		if _, ok := src[k]; !ok {
-			delete(dest, k)
+			delete(result, k)
 		}
 	}
 

--- a/types/mapper/annotation_field.go
+++ b/types/mapper/annotation_field.go
@@ -38,7 +38,7 @@ func (e AnnotationField) FromInternal(data map[string]interface{}) {
 
 func (e AnnotationField) ToInternal(data map[string]interface{}) {
 	v, ok := data[e.Field]
-	if ok && v != nil {
+	if ok {
 		if e.Object || e.List {
 			if bytes, err := json.Marshal(v); err == nil {
 				v = string(bytes)


### PR DESCRIPTION
- Do not drop a field-to-annotation conversion if the value of the field is
nil. The user is excplicitly trying to set it to nil
- Never delete field annotations, even if they are not in the new map of
annotations sent by the user.
- Prevent the modification of the creatorId field, which is a special case
field that should be considered protected