### PR TITLE
Update doAction to not expect a response

### DIFF
--- a/clientbase/ops.go
+++ b/clientbase/ops.go
@@ -285,6 +285,10 @@ func (a *APIOperations) doAction(
 
 	var input io.Reader
 
+	if debug {
+		fmt.Println("POST " + actionURL)
+	}
+
 	if inputObject != nil {
 		bodyContent, err := json.Marshal(inputObject)
 		if err != nil {
@@ -325,5 +329,8 @@ func (a *APIOperations) doAction(
 		fmt.Println("Response <= " + string(byteContent))
 	}
 
-	return json.Unmarshal(byteContent, respObject)
+	if nil != respObject {
+		return json.Unmarshal(byteContent, respObject)
+	}
+	return nil
 }


### PR DESCRIPTION
Problem:
doAction assumes that an action would have a response body which causes
JSON unmarshal errors

Solution:
Only attempt to Unmarshal when a response is expected