### PR TITLE
dont marshal nil

### DIFF
--- a/types/mapper/annotation_field.go
+++ b/types/mapper/annotation_field.go
@@ -39,7 +39,7 @@ func (e AnnotationField) FromInternal(data map[string]interface{}) {
 func (e AnnotationField) ToInternal(data map[string]interface{}) {
 	v, ok := data[e.Field]
 	if ok {
-		if e.Object || e.List {
+		if (e.Object || e.List) && v != nil {
 			if bytes, err := json.Marshal(v); err == nil {
 				v = string(bytes)
 			}


### PR DESCRIPTION
Marshalling nil creates a string "null" value, which is then
saved as the value of the annotation. We want "" to be saved in
this case.

needed by https://github.com/rancher/rancher/pull/13188