### PR TITLE
Adding error if not a pointer

### DIFF
--- a/types/reflection.go
+++ b/types/reflection.go
@@ -48,6 +48,10 @@ func (s *Schemas) AddMapperForType(version *APIVersion, obj interface{}, mapper 
 }
 
 func (s *Schemas) MustImport(version *APIVersion, obj interface{}, externalOverrides ...interface{}) *Schemas {
+	if reflect.ValueOf(obj).Kind() == reflect.Ptr {
+		panic(fmt.Errorf("obj cannot be a pointer"))
+	}
+
 	if _, err := s.Import(version, obj, externalOverrides...); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This change adds an early panic if the type of the obj supplied to the
`MustImport` func is a pointer.  This is to prevent a later, cryptic,
error that is not as clear to diagnose.