### PR TITLE
DnsLabelRestricted type to validate against RFC 1035

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -78,6 +78,8 @@ func getTypeString(nullable bool, typeName string, schema *types.Schema, schemas
 		return "intstr.IntOrString"
 	case "dnsLabel":
 		return "string"
+	case "dnsLabelRestricted":
+		return "string"
 	case "hostname":
 		return "string"
 	default:

--- a/parse/builder/builder.go
+++ b/parse/builder/builder.go
@@ -272,6 +272,18 @@ func (b *Builder) convert(fieldType string, value interface{}, op Operation) (in
 			}
 		}
 		return str, nil
+	case "dnsLabelRestricted":
+		str := convert.ToString(value)
+		if str == "" {
+			return "", nil
+		}
+		if op == Create || op == Update {
+			if errs := validation.IsDNS1035Label(str); len(errs) != 0 {
+				return value, httperror.NewAPIError(httperror.InvalidFormat, fmt.Sprintf("invalid value %s: %s", value,
+					strings.Join(errs, ",")))
+			}
+		}
+		return str, nil
 	case "hostname":
 		str := convert.ToString(value)
 		if str == "" {


### PR DESCRIPTION
k8s uses restricted format for services

dnsLabelRestricted: dns1035LabelFmt string = "[a-z]([-a-z0-9]*[a-z0-9])?"
dnsLabel:dns1123LabelFmt string = "[a-z0-9]([-a-z0-9]*[a-z0-9])?"


https://github.com/rancher/rancher/issues/13498

@ibuildthecloud just wanted to make sure you are ok with the name; didn't want to use explicit 1035 in the name