### PR TITLE
Changes to Mapper embed to insert nil value if applicable for a schema field

### DIFF
--- a/types/mapper/embed.go
+++ b/types/mapper/embed.go
@@ -13,6 +13,7 @@ type Embed struct {
 	Ignore         []string
 	ignoreOverride bool
 	embeddedFields []string
+	EmptyValueOk   bool
 }
 
 func (e *Embed) FromInternal(data map[string]interface{}) {
@@ -39,6 +40,9 @@ func (e *Embed) ToInternal(data map[string]interface{}) {
 		delete(data, fieldName)
 	}
 	if len(sub) == 0 {
+		if e.EmptyValueOk {
+			data[e.Field] = nil
+		}
 		return
 	}
 	data[e.Field] = sub


### PR DESCRIPTION
Need to let embed.go mapper to insert a nil value for a field if mentioned in the schema. 
Usecase for this: In cases where an Update on the resource will be removing some field, we need to update the existing k8s resource's field by setting its  value to explicit nil.

https://github.com/rancher/rancher/issues/13584

@alena1108 review pls