### PR TITLE
Use logrus to log errors and panics

### DIFF
--- a/controller/generic_controller.go
+++ b/controller/generic_controller.go
@@ -201,7 +201,7 @@ func (g *genericController) processNextWorkItem() bool {
 	}
 
 	if err := filterConflictsError(err); err != nil {
-		utilruntime.HandleError(fmt.Errorf("%v %v %v", g.name, key, err))
+		logrus.Errorf("%v %v %v", g.name, key, err)
 	}
 
 	g.queue.AddRateLimited(key)


### PR DESCRIPTION
This changes the framework from using glog to using logrus, which is
what the rest of code uses.