### PR TITLE
return on first try if err is not conflict

### DIFF
--- a/store/proxy/proxy_store.go
+++ b/store/proxy/proxy_store.go
@@ -382,6 +382,7 @@ func (s *Store) Update(apiContext *types.APIContext, schema *types.Schema, data 
 		if errors.IsConflict(err) {
 			continue
 		}
+		return result, err
 	}
 
 	return result, err


### PR DESCRIPTION
To test, I used
```
    cluster = admin_cc.cluster
    count = 0
    for i in range(0,50):
        print(i)
        time.sleep(10)
        try:
            curr = cluster.data_dict()['enableNetworkPolicy']
            upd = not curr
            cluster = admin_cc.management.client.update(cluster,id='c-7cnlz',name='custom',
                rancherKubernetesEngineConfig=cluster.data_dict()['rancherKubernetesEngineConfig'],
                enableNetworkPolicy=upd)
            assert cluster.data_dict()['enableNetworkPolicy'] == upd
        except ApiError as e:
            assert e.value.error.status != 409
            count = count + 1

    assert count == 0
``` 
https://github.com/rancher/rancher/issues/14940 