### PR TITLE
Log forget error in debug

### DIFF
--- a/controller/generic_controller.go
+++ b/controller/generic_controller.go
@@ -204,7 +204,7 @@ func (g *genericController) processNextWorkItem() bool {
 	}
 	if _, ok := checkErr.(*ForgetError); err == nil || ok {
 		if ok {
-			logrus.Infof("%v %v completed with dropped err: %v", g.name, key, err)
+			logrus.Debugf("%v %v completed with dropped err: %v", g.name, key, err)
 		}
 		g.queue.Forget(key)
 		return true


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/13049

@ibuildthecloud do you see any problem with reducing the log level for this particular type of error? 