### PR TITLE
add method to compare if error has tmp file path

### DIFF
--- a/condition/condition_test.go
+++ b/condition/condition_test.go
@@ -1,0 +1,19 @@
+package condition
+
+import "testing"
+
+func TestRegexp(t *testing.T) {
+	testInputs := []string{
+		"create file /tmp/file-uy76324 ",
+		"/tmp/file-y6123tsd",
+	}
+	testOutputs := []string{
+		"create file file_path_redacted ",
+		"file_path_redacted",
+	}
+	for i, s := range testInputs {
+		if testOutputs[i] != temfileRegexp.ReplaceAllString(s, "file_path_redacted") {
+			t.Fatalf("Regexp failed to check %s", testInputs[i])
+		}
+	}
+}


### PR DESCRIPTION
add a method to check if the error message contains a tmp file path. It
is to prevent updating resource's condition forever and causing the
controller flapping. https://github.com/rancher/rancher/issues/15103