### PR TITLE
Add dynamic field to field struct

### DIFF
--- a/types/schemas.go
+++ b/types/schemas.go
@@ -170,7 +170,12 @@ func (s *Schemas) embed(schema *Schema) {
 	newSchema.ResourceFields = map[string]Field{}
 
 	for k, v := range target.ResourceFields {
-		newSchema.ResourceFields[k] = v
+		// We remove the dynamic fields off the existing schema in case
+		// they've been removed from the dynamic schema so they won't
+		// be accidentally left over
+		if !v.DynamicField {
+			newSchema.ResourceFields[k] = v
+		}
 	}
 	for k, v := range schema.ResourceFields {
 		newSchema.ResourceFields[k] = v

--- a/types/types.go
+++ b/types/types.go
@@ -136,6 +136,7 @@ type Field struct {
 	InvalidChars string      `json:"invalidChars,omitempty"`
 	Description  string      `json:"description,omitempty"`
 	CodeName     string      `json:"-"`
+	DynamicField bool        `json:"dynamicField,omitempty"`
 }
 
 type Action struct {


### PR DESCRIPTION
This change adds a dynamic field indicator to the field struct.  This is so
we can remove the dynamic fields from an existing schema before merging the
dynamic schema and actual schema to prevent removed dynamic fields form being
incorrectly left behind on the schema.

Issue:
https://github.com/rancher/rancher/issues/12698