### PR TITLE
Enable filter namespaces on server side

### DIFF
--- a/store/proxy/proxy_store.go
+++ b/store/proxy/proxy_store.go
@@ -283,10 +283,11 @@ func getNamespace(apiContext *types.APIContext, opt *types.QueryOptions) string 
 	}
 
 	for _, condition := range opt.Conditions {
-		if condition.Field == "namespaceId" && condition.Value != "" {
+		mod := condition.ToCondition().Modifier
+		if condition.Field == "namespaceId" && condition.Value != "" && mod != types.ModifierIn && mod != types.ModifierNotIn {
 			return condition.Value
 		}
-		if condition.Field == "namespace" && condition.Value != "" {
+		if condition.Field == "namespace" && condition.Value != "" && mod != types.ModifierIn && mod != types.ModifierNotIn {
 			return condition.Value
 		}
 	}


### PR DESCRIPTION
When trying to integrate our [services](https://github.com/refunc/refunc-rancher), we use norman to build a rancher compatible api server. In order to utilize rancher's Project, [frontend](https://github.com/refunc/rancher-ui) (the attached screenshot)  needs to select resources in some namespaces belong to the same project.

This PR enables the filter 'in' on namespaces, to allow server side select resources in a subset of namespaces

![image](https://user-images.githubusercontent.com/354668/44560210-1b926980-a781-11e8-8ea2-a8e292c17c27.png)
