### PR TITLE
Revert "Revert "Don't strip strings on output""

### DIFF
--- a/parse/builder/builder.go
+++ b/parse/builder/builder.go
@@ -330,6 +330,9 @@ func ConvertSimple(fieldType string, value interface{}, op Operation) (interface
 	case "password":
 		return convert.ToString(value), nil
 	case "string":
+		if op.IsList() {
+			return convert.ToStringNoTrim(value), nil
+		}
 		return convert.ToString(value), nil
 	case "dnsLabel":
 		str := convert.ToString(value)

--- a/types/convert/convert.go
+++ b/types/convert/convert.go
@@ -44,7 +44,7 @@ func Singular(value interface{}) interface{} {
 	return value
 }
 
-func ToString(value interface{}) string {
+func ToStringNoTrim(value interface{}) string {
 	if t, ok := value.(time.Time); ok {
 		return t.Format(time.RFC3339)
 	}
@@ -52,7 +52,11 @@ func ToString(value interface{}) string {
 	if single == nil {
 		return ""
 	}
-	return strings.TrimSpace(fmt.Sprint(single))
+	return fmt.Sprint(single)
+}
+
+func ToString(value interface{}) string {
+	return strings.TrimSpace(ToStringNoTrim(value))
 }
 
 func ToTimestamp(value interface{}) (int64, error) {


### PR DESCRIPTION
This change is in support of the CA linefeed fix.  Reverts a reverted commit so whitespace are not automatically stripped on lists.

Issue:
https://github.com/rancher/rancher/issues/13831

This reverts commit 4bcc025ae37faa5f4a8a6614df4e8133530f84d2.