### PR TITLE
don't error out when decoding objects of kind status

### DIFF
--- a/objectclient/object_client.go
+++ b/objectclient/object_client.go
@@ -256,15 +256,12 @@ func (d *structuredDecoder) Decode(data []byte, defaults *schema.GroupVersionKin
 
 	err := json.Unmarshal(data, &into)
 	if err != nil {
-		return nil, nil, err
-	}
-
-	if _, ok := into.(*metav1.Status); !ok && strings.ToLower(into.GetObjectKind().GroupVersionKind().Kind) == "status" {
-		into = &metav1.Status{}
-		err := json.Unmarshal(data, into)
-		if err != nil {
+		if _, ok := into.(*metav1.Status); !ok && strings.ToLower(into.GetObjectKind().GroupVersionKind().Kind) == "status" {
+			into = &metav1.Status{}
+			err := json.Unmarshal(data, into)
 			return nil, nil, err
 		}
+		return nil, nil, err
 	}
 
 	return into, defaults, err


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/12332

I am not sure if there's some other reason why need this check even if Unmarshal succeeds. 
But based on when I saw this error, I think it needs to check when Unmarshal fails and return nil if it is of type Status. 

```
2018/09/12 17:17:28 [INFO] {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"too old resource version: 4283 (4727)","reason":"Gone","code":410}
E0912 17:17:28.206907   19481 streamwatcher.go:111] Unable to decode an event from the watch stream: unable to decode watch event: json: cannot unmarshal string into Go struct field Node.status of type v3.NodeStatus
```
