### PR TITLE
Allow to put Reason in controller.ForgetError

### DIFF
--- a/condition/condition.go
+++ b/condition/condition.go
@@ -89,9 +89,16 @@ func (c Cond) ReasonAndMessageFromError(obj runtime.Object, err error) {
 	}
 	cond := findOrCreateCond(obj, string(c))
 	setValue(cond, "Message", err.Error())
-	if ce, ok := err.(*conditionError); ok {
+	switch ce := err.(type) {
+	case *conditionError:
 		setValue(cond, "Reason", ce.reason)
-	} else {
+	case *controller.ForgetError:
+		if ce.Reason != "" {
+			setValue(cond, "Reason", ce.Reason)
+		} else {
+			setValue(cond, "Reason", "Error")
+		}
+	default:
 		setValue(cond, "Reason", "Error")
 	}
 }

--- a/controller/error.go
+++ b/controller/error.go
@@ -1,7 +1,8 @@
 package controller
 
 type ForgetError struct {
-	Err error
+	Err    error
+	Reason string
 }
 
 func (f *ForgetError) Error() string {


### PR DESCRIPTION
Norman Condition automatically generate condition information based on
the error the handler would return in Condition.Do function.
handler function usually return 2 types of error. the error can be
ignored and the error can not be ignored.
According to current implementation, Condition.Do function generate
condition with error state even if handler return error can be ignored.
The error that can be ignored should be ignored in the context of
condition as well.

So this commit introduce new field which is Reason to ForgetError so
that the developer can put special reason other than Error when
ForgetError is expected to happen by expected procedure like
provisioning and wait for something and Norman Condintion respect to
this field when try to generate condition information based on error

This solution will help us to fix this rancher bug
https://github.com/rancher/rancher/issues/15907