### PR TITLE
Add float support for Rancher API

### DIFF
--- a/parse/builder/builder.go
+++ b/parse/builder/builder.go
@@ -327,6 +327,8 @@ func ConvertSimple(fieldType string, value interface{}, op Operation) (interface
 		return convert.ToString(value), nil
 	case "int":
 		return convert.ToNumber(value)
+	case "float":
+		return convert.ToFloat(value)
 	case "password":
 		return convert.ToString(value), nil
 	case "string":

--- a/types/convert/convert.go
+++ b/types/convert/convert.go
@@ -105,6 +105,30 @@ func ToNumber(value interface{}) (int64, error) {
 	return strconv.ParseInt(ToString(value), 10, 64)
 }
 
+func ToFloat(value interface{}) (float64, error) {
+	value = Singular(value)
+
+	f64, ok := value.(float64)
+	if ok {
+		return f64, nil
+	}
+
+	f32, ok := value.(float32)
+	if ok {
+		return float64(f32), nil
+	}
+
+	if n, ok := value.(json.Number); ok {
+		i, err := n.Int64()
+		if err == nil {
+			return float64(i), nil
+		}
+		f, err := n.Float64()
+		return float64(f), err
+	}
+	return strconv.ParseFloat(ToString(value), 64)
+}
+
 func Capitalize(s string) string {
 	if len(s) <= 1 {
 		return strings.ToUpper(s)


### PR DESCRIPTION
As https://github.com/rancher/api-spec/blob/master/specification.md#schema-fields, we should support float type in Rancher API. The metrics type of monitoring has a value field that should be float type.

Related issue: https://github.com/rancher/rancher/issues/14230