### PR TITLE
Support creating user cluster crds

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -51,7 +51,7 @@ func main() {
 	}
 
 	Schemas.MustImportAndCustomize(&version, Foo{}, func(schema *types.Schema) {
-		if err := crdFactory.AssignStores(context.Background(), types.DefaultStorageContext, schema); err != nil {
+		if err := crdFactory.AssignStores(context.Background(), types.DefaultStorageContext, &version, schema); err != nil {
 			panic(err)
 		}
 	})


### PR DESCRIPTION
Related issue: https://github.com/rancher/rancher/issues/14230

When we call `CreateCRDs` function, we can use the api version to create the crds instead of the one in schema. Then we can create our own crds with customized group and version.