### PR TITLE
reduce watch timeout from 1hr to 30min to align with azure max load b…

### DIFF
--- a/restwatch/rest.go
+++ b/restwatch/rest.go
@@ -21,7 +21,7 @@ func UnversionedRESTClientFor(config *rest.Config) (rest.Interface, error) {
 	}
 
 	newConfig := *config
-	newConfig.Timeout = time.Hour
+	newConfig.Timeout = 30 * time.Minute
 	watchClient, err := rest.UnversionedRESTClientFor(&newConfig)
 	if err != nil {
 		return nil, err

--- a/store/proxy/proxy_store.go
+++ b/store/proxy/proxy_store.go
@@ -256,7 +256,7 @@ func (s *Store) realWatch(apiContext *types.APIContext, schema *types.Schema, op
 		k8sClient = watchClient.WatchClient()
 	}
 
-	timeout := int64(60 * 60)
+	timeout := int64(60 * 30)
 	req := s.common(namespace, k8sClient.Get())
 	req.VersionedParams(&metav1.ListOptions{
 		Watch:           true,


### PR DESCRIPTION
…alancer idle timeouts

Rancher frequently loses its proxy and watch connections to AKS clusters leading to timeouts while browsing the UI as well as delayed Catalog App deployments. The likely root cause of these failures is the Basic Azure Load Balancer limitation where it doesn't send tcpReset (RST) after an idle timeout. This leads to zombie client connections.

The idle timeout for the azure basic load balancers in front of AKS clusters is set to the maximum of 30 minutes. Adjust the rancher watch timeouts to align with that setting to ensure watches are always refreshed before an idle timeout from the azure load balancer.