### PR TITLE
Reduce generic controller rate limiter max delay

### DIFF
--- a/controller/generic_controller.go
+++ b/controller/generic_controller.go
@@ -92,7 +92,7 @@ func NewGenericController(name string, genericClient Backend) GenericController 
 		genericClient.ObjectFactory().Object(), resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 
 	rl := workqueue.NewMaxOfRateLimiter(
-		workqueue.NewItemExponentialFailureRateLimiter(500*time.Millisecond, 1000*time.Second),
+		workqueue.NewItemExponentialFailureRateLimiter(500*time.Millisecond, 30*time.Second),
 		// 10 qps, 100 bucket size.  This is only for retry speed and its only the overall factor (not per item)
 		&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
 	)


### PR DESCRIPTION
Changes the backoff of failures from maximum of 1000 seconds to 30
seconds.

For rancher/rancher/issues/16213