### PR TITLE
Adding ability to replace schemas

### DIFF
--- a/types/schemas.go
+++ b/types/schemas.go
@@ -108,10 +108,16 @@ func (s *Schemas) removeReferences(schema *Schema) {
 func (s *Schemas) AddSchema(schema Schema) *Schemas {
 	s.Lock()
 	defer s.Unlock()
-	return s.doAddSchema(schema)
+	return s.doAddSchema(schema, false)
 }
 
-func (s *Schemas) doAddSchema(schema Schema) *Schemas {
+func (s *Schemas) ForceAddSchema(schema Schema) *Schemas {
+	s.Lock()
+	defer s.Unlock()
+	return s.doAddSchema(schema, true)
+}
+
+func (s *Schemas) doAddSchema(schema Schema, replace bool) *Schemas {
 	s.setupDefaults(&schema)
 
 	if s.AddHook != nil {
@@ -125,9 +131,20 @@ func (s *Schemas) doAddSchema(schema Schema) *Schemas {
 		s.versions = append(s.versions, schema.Version)
 	}
 
-	if _, ok := schemas[schema.ID]; !ok {
+	if _, ok := schemas[schema.ID]; !ok ||
+		(replace && schema.DynamicSchemaVersion != schemas[schema.ID].DynamicSchemaVersion) {
 		schemas[schema.ID] = &schema
-		s.schemas = append(s.schemas, &schema)
+
+		if replace {
+			for i, candidate := range s.schemas {
+				if candidate.ID == schema.ID {
+					s.schemas[i] = &schema
+					break
+				}
+			}
+		} else {
+			s.schemas = append(s.schemas, &schema)
+		}
 
 		if !schema.Embed {
 			s.addReferences(&schema)
@@ -159,7 +176,7 @@ func (s *Schemas) removeEmbed(schema *Schema) {
 	}
 
 	s.doRemoveSchema(*target)
-	s.doAddSchema(newSchema)
+	s.doAddSchema(newSchema, false)
 }
 
 func (s *Schemas) embed(schema *Schema) {
@@ -184,7 +201,7 @@ func (s *Schemas) embed(schema *Schema) {
 	}
 
 	s.doRemoveSchema(*target)
-	s.doAddSchema(newSchema)
+	s.doAddSchema(newSchema, false)
 }
 
 func (s *Schemas) addReferences(schema *Schema) {

--- a/types/types.go
+++ b/types/types.go
@@ -94,25 +94,26 @@ var NamespaceScope TypeScope = "namespace"
 type TypeScope string
 
 type Schema struct {
-	ID                string            `json:"id,omitempty"`
-	Embed             bool              `json:"embed,omitempty"`
-	EmbedType         string            `json:"embedType,omitempty"`
-	CodeName          string            `json:"-"`
-	CodeNamePlural    string            `json:"-"`
-	PkgName           string            `json:"-"`
-	Type              string            `json:"type,omitempty"`
-	BaseType          string            `json:"baseType,omitempty"`
-	Links             map[string]string `json:"links"`
-	Version           APIVersion        `json:"version"`
-	PluralName        string            `json:"pluralName,omitempty"`
-	ResourceMethods   []string          `json:"resourceMethods,omitempty"`
-	ResourceFields    map[string]Field  `json:"resourceFields"`
-	ResourceActions   map[string]Action `json:"resourceActions,omitempty"`
-	CollectionMethods []string          `json:"collectionMethods,omitempty"`
-	CollectionFields  map[string]Field  `json:"collectionFields,omitempty"`
-	CollectionActions map[string]Action `json:"collectionActions,omitempty"`
-	CollectionFilters map[string]Filter `json:"collectionFilters,omitempty"`
-	Scope             TypeScope         `json:"-"`
+	ID                   string            `json:"id,omitempty"`
+	Embed                bool              `json:"embed,omitempty"`
+	EmbedType            string            `json:"embedType,omitempty"`
+	CodeName             string            `json:"-"`
+	CodeNamePlural       string            `json:"-"`
+	PkgName              string            `json:"-"`
+	Type                 string            `json:"type,omitempty"`
+	BaseType             string            `json:"baseType,omitempty"`
+	Links                map[string]string `json:"links"`
+	Version              APIVersion        `json:"version"`
+	PluralName           string            `json:"pluralName,omitempty"`
+	ResourceMethods      []string          `json:"resourceMethods,omitempty"`
+	ResourceFields       map[string]Field  `json:"resourceFields"`
+	ResourceActions      map[string]Action `json:"resourceActions,omitempty"`
+	CollectionMethods    []string          `json:"collectionMethods,omitempty"`
+	CollectionFields     map[string]Field  `json:"collectionFields,omitempty"`
+	CollectionActions    map[string]Action `json:"collectionActions,omitempty"`
+	CollectionFilters    map[string]Filter `json:"collectionFilters,omitempty"`
+	DynamicSchemaVersion string            `json:"dynamicSchemaVersion,omitempty"`
+	Scope                TypeScope         `json:"-"`
 
 	InternalSchema      *Schema             `json:"-"`
 	Mapper              Mapper              `json:"-"`


### PR DESCRIPTION
This change makes it so that schemas can be replaced when they already exist.
This is to support the ability for kontainer drivers to update their dynamic
schemas.

Issue:
https://github.com/rancher/rancher/issues/17712