### PR TITLE
Fix concurrent map read/write

### DIFF
--- a/objectclient/object_client.go
+++ b/objectclient/object_client.go
@@ -102,6 +102,13 @@ func (p *ObjectClient) Create(o runtime.Object) (runtime.Object, error) {
 		labels := obj.GetLabels()
 		if labels == nil {
 			labels = make(map[string]string)
+		} else {
+			ls := make(map[string]string)
+			for k, v := range labels {
+				ls[k] = v
+			}
+			labels = ls
+
 		}
 		labels["cattle.io/creator"] = "norman"
 		obj.SetLabels(labels)


### PR DESCRIPTION
Problem:
If you set a resource's labels to a global/shared map variable,
norman will modify that map by adding a label. In race conditions,
this can cause a concurrent map read/write panic.

Solution:
Copy the map in norman before modifying it.


https://github.com/rancher/rancher/issues/18036