### PR TITLE
Adding code to address aks timeout issue

### DIFF
--- a/pkg/remotedialer/client_dialer.go
+++ b/pkg/remotedialer/client_dialer.go
@@ -16,7 +16,11 @@ func clientDial(dialer Dialer, conn *connection, message *message) {
 	)
 
 	if dialer == nil {
-		netConn, err = net.DialTimeout(message.proto, message.address, time.Duration(message.deadline)*time.Millisecond)
+		netDialer := &net.Dialer{
+			Timeout:   time.Duration(message.deadline) * time.Millisecond,
+			KeepAlive: 30 * time.Second,
+		}
+		netConn, err = netDialer.Dial(message.proto, message.address)
 	} else {
 		netConn, err = dialer(message.proto, message.address)
 	}

--- a/restwatch/rest.go
+++ b/restwatch/rest.go
@@ -21,7 +21,7 @@ func UnversionedRESTClientFor(config *rest.Config) (rest.Interface, error) {
 	}
 
 	newConfig := *config
-	newConfig.Timeout = time.Hour
+	newConfig.Timeout = 30 * time.Minute
 	watchClient, err := rest.UnversionedRESTClientFor(&newConfig)
 	if err != nil {
 		return nil, err

--- a/store/proxy/proxy_store.go
+++ b/store/proxy/proxy_store.go
@@ -256,7 +256,7 @@ func (s *Store) realWatch(apiContext *types.APIContext, schema *types.Schema, op
 		k8sClient = watchClient.WatchClient()
 	}
 
-	timeout := int64(60 * 60)
+	timeout := int64(60 * 30)
 	req := s.common(namespace, k8sClient.Get())
 	req.VersionedParams(&metav1.ListOptions{
 		Watch:           true,


### PR DESCRIPTION
This change addresses an issue where AKS clusters would timeout due to Azure
lbs failing to send tcpResets (RST) after an idle timeout. This causes errors
to appear on the Rancher UI and logs. This issue resolves that by adding a
keep alive to the dialer and changing some timeouts to prevent the errors from
appearing.

This is only for AKS cluster provisioned through the AKS Kontainer Driver
integration, imported clusters still exhibit this behavior.

Issue:
https://github.com/rancher/rancher/issues/14354