### PR TITLE
Increase remotedialer timeouts

### DIFF
--- a/pkg/remotedialer/server.go
+++ b/pkg/remotedialer/server.go
@@ -56,7 +56,7 @@ func (s *Server) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	logrus.Infof("Handling backend connection request [%s]", clientKey)
 
 	upgrader := websocket.Upgrader{
-		HandshakeTimeout: 5 * time.Second,
+		HandshakeTimeout: 30 * time.Second,
 		CheckOrigin:      func(r *http.Request) bool { return true },
 		Error:            s.errorWriter,
 	}

--- a/pkg/remotedialer/types.go
+++ b/pkg/remotedialer/types.go
@@ -5,7 +5,6 @@ import (
 )
 
 var (
-	PingWaitDuration  = time.Duration(10 * time.Second)
-	PingWriteInterval = time.Duration(5 * time.Second)
-	MaxRead           = 8192
+	PingWaitDuration  = time.Duration(time.Minute)
+	PingWriteInterval = time.Duration(10 * time.Second)
 )


### PR DESCRIPTION
Poor networks may cause connectivity issues with connection i/o
timeouts if messages do not arrive within PingWaitDuration. Increase
PingWaitDuration from 10 seconds to 60 seconds, increase
PingWriteInterval from 5 seconds to 10 seconds, and increase websocket
handshake timeout from 5 seconds to 30 seconds.