### PR TITLE
Fix DoModify crashing on nil objects

### DIFF
--- a/clientbase/ops.go
+++ b/clientbase/ops.go
@@ -120,6 +120,12 @@ func (a *APIOperations) DoNext(nextURL string, respObject interface{}) error {
 }
 
 func (a *APIOperations) DoModify(method string, url string, createObj interface{}, respObject interface{}) error {
+	if createObj == nil {
+		createObj = map[string]string{}
+	}
+	if respObject == nil {
+		respObject = &map[string]interface{}{}
+	}
 	bodyContent, err := json.Marshal(createObj)
 	if err != nil {
 		return err


### PR DESCRIPTION
Other methods such as `DoCreate` handle nil `createObj` and `respObject` by initializing the variables. `DoModify` contains no such checks.

Rancher Terraform provider ignores the response and passes nil, which then crashes with `json: Unmarshal(nil)` https://github.com/rancher/terraform-provider-rancher2/blob/master/rancher2/resource_rancher2_auth_config_adfs.go#L244

This issue manifested here https://github.com/rancher/terraform-provider-rancher2/issues/59