### PR TITLE
ensure resp.Body closed

### DIFF
--- a/clientbase/common.go
+++ b/clientbase/common.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -216,7 +217,9 @@ func NewAPIClient(opts *ClientOpts) (APIBaseClient, error) {
 	if err != nil {
 		return result, err
 	}
-	defer resp.Body.Close()
+	defer func(closer io.Closer) {
+		closer.Close()
+	}(resp.Body)
 
 	if resp.StatusCode != 200 {
 		return result, NewAPIError(resp, opts.URL)
@@ -242,7 +245,9 @@ func NewAPIClient(opts *ClientOpts) (APIBaseClient, error) {
 		if err != nil {
 			return result, err
 		}
-		defer resp.Body.Close()
+		defer func(closer io.Closer) {
+			closer.Close()
+		}(resp.Body)
 
 		if resp.StatusCode != 200 {
 			return result, NewAPIError(resp, schemasURLs)


### PR DESCRIPTION
In the old code, `resp` defined at line 215 will be rewrite at line 241. So that the `resp` after `defer` at both line 219 and 245 will operate the same one. And the other one leaks.