### PR TITLE
Track namespaces in options property

### DIFF
--- a/types/server_types.go
+++ b/types/server_types.go
@@ -184,6 +184,8 @@ type QueryOptions struct {
 	Pagination *Pagination
 	Conditions []*QueryCondition
 	Options    map[string]string
+	// Set namespaces to an empty array will result in an empty response
+	Namespaces []string
 }
 
 type ReferenceValidator interface {


### PR DESCRIPTION
Problem:
Requests associated with a particular project are not being filtered. Consequently, requests for projects that posses a fraction of total resources are taking longer than necessary to return.

Solution:
Norman now tracks and assigns project namespaces which are necessary for rancher to filter project requests.

Issues:
https://github.com/rancher/rancher/issues/18870
https://github.com/rancher/rancher/issues/18522
https://github.com/rancher/rancher/issues/18295
https://github.com/rancher/rancher/issues/16605