### PR TITLE
Log server error response when websocket handshake fails

### DIFF
--- a/pkg/remotedialer/client.go
+++ b/pkg/remotedialer/client.go
@@ -27,16 +27,16 @@ func connectToProxy(proxyURL string, headers http.Header, auth ConnectAuthorizer
 	}
 	ws, resp, err := dialer.Dial(proxyURL, headers)
 	if err != nil {
-		if err == websocket.ErrBadHandshake {
+		if err == websocket.ErrBadHandshake && resp != nil {
 			// The websocket library returns ErrBadHandshake when the server response
 			// to opening handshake is invalid. To facilitate troubleshooting we log
-			// a junk of the response body as the server might have written an error.
+			// a part of the response body as the server might have returned an error.
 			respBytes := make([]byte, 256)
 			io.ReadFull(resp.Body, respBytes)
 			resp.Body.Close()
 			logrus.WithFields(logrus.Fields{
-				"StatusCode": resp.StatusCode,
-				"Body":       string(respBytes),
+				"Status": resp.Status,
+				"Body":   string(respBytes),
 			}).Error("Invalid proxy response")
 		}
 		return err

--- a/pkg/remotedialer/server.go
+++ b/pkg/remotedialer/server.go
@@ -63,7 +63,8 @@ func (s *Server) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 	wsConn, err := upgrader.Upgrade(rw, req, nil)
 	if err != nil {
-		s.errorWriter(rw, req, 400, errors.Wrapf(err, "Error during upgrade for host [%v]", clientKey))
+		// Upgrade method takes care of returning the error to the client
+		logrus.WithError(err).Errorf("Error during upgrade for host [%v]", clientKey)
 		return
 	}
 

--- a/pkg/remotedialer/server.go
+++ b/pkg/remotedialer/server.go
@@ -19,8 +19,8 @@ type Authorizer func(req *http.Request) (clientKey string, authed bool, err erro
 type ErrorWriter func(rw http.ResponseWriter, req *http.Request, code int, err error)
 
 func DefaultErrorWriter(rw http.ResponseWriter, req *http.Request, code int, err error) {
-	rw.Write([]byte(err.Error()))
 	rw.WriteHeader(code)
+	rw.Write([]byte(err.Error()))
 }
 
 type Server struct {


### PR DESCRIPTION
It's very difficult to troubleshoot websocket connection issues between agent and server like [this](https://github.com/rancher/rancher/issues/18831#issuecomment-479547159) one:

1. Any errors (auth, malformatted headers, etc...) occuring during the websocket handshake are returned in the HTTP response to the client using the `DefaultErrorWriter` passed to the websocket `Upgrader` instance. They are never logged in the server log.
https://github.com/rancher/norman/blob/6c7654a69fb674058c6a4c9ce9e9dcf7d5113bdc/pkg/remotedialer/server.go#L21-L24

2. The client in the agent gobbles up this error because it does not evaluate the HTTP response body and instead logs a helpful (not) `bad handshake` error.

3. Finally there is a bug where the server tries to write the HTTP error response twice (the `Upgrader` has at this point already written the response):
https://github.com/rancher/norman/blob/6c7654a69fb674058c6a4c9ce9e9dcf7d5113bdc/pkg/remotedialer/server.go#L65-L68
Since writing the header for the same response object a second time is not allowed, the response never reaches the client and following warning is logged in server:
> http: multiple response.WriteHeader calls
