### PR TITLE
Add no pagination option

### DIFF
--- a/parse/collection.go
+++ b/parse/collection.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	defaultLimit = int64(1000)
-	maxLimit     = int64(3000)
+	maxLimit     = int64(10000)
 )
 
 func QueryOptions(apiContext *types.APIContext, schema *types.Schema) types.QueryOptions {
@@ -67,7 +67,7 @@ func parsePagination(apiContext *types.APIContext) *types.Pagination {
 			return result
 		}
 
-		if limitInt > maxLimit {
+		if limitInt > maxLimit || limitInt == -1 {
 			result.Limit = &maxLimit
 		} else if limitInt >= 0 {
 			result.Limit = &limitInt


### PR DESCRIPTION
Problem:
Response times are too slow for resources such as pods. The UI is making paged requests. Since response are paginated after processing, each paged response takes about the same amount of time for the backend to process as a full response. Pagination is not being used to fragment results and -1 is being passed as a parameter by the UI.

Solution:
There is now a recognized option for opting out of pagination. Now, a value of -1 will prevent the response from being paginated.

Issue:
https://github.com/rancher/rancher/issues/18870
https://github.com/rancher/rancher/issues/18522
https://github.com/rancher/rancher/issues/18295