### PR TITLE
Configure HandshakeTimeout in websocket.Dialer

### DIFF
--- a/clientbase/common.go
+++ b/clientbase/common.go
@@ -277,7 +277,7 @@ func NewAPIClient(opts *ClientOpts) (APIBaseClient, error) {
 	result.Ops = &APIOperations{
 		Opts:   opts,
 		Client: client,
-		Dialer: &websocket.Dialer{},
+		Dialer: &websocket.Dialer{HandshakeTimeout: 10 * time.Second},
 		Types:  result.Types,
 	}
 

--- a/pkg/remotedialer/client.go
+++ b/pkg/remotedialer/client.go
@@ -22,7 +22,7 @@ func connectToProxy(proxyURL string, headers http.Header, auth ConnectAuthorizer
 	logrus.WithField("url", proxyURL).Info("Connecting to proxy")
 
 	if dialer == nil {
-		dialer = &websocket.Dialer{}
+		dialer = &websocket.Dialer{HandshakeTimeout: 10 * time.Second}
 	}
 	ws, _, err := dialer.Dial(proxyURL, headers)
 	if err != nil {

--- a/pkg/remotedialer/peer.go
+++ b/pkg/remotedialer/peer.go
@@ -79,6 +79,7 @@ func (p *peer) start(ctx context.Context, s *Server) {
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
 		},
+		HandshakeTimeout: 10 * time.Second,
 	}
 
 outer:


### PR DESCRIPTION
To prevent agent from being hung in the middle of Websocket Session
Handshake, We'd better to set HandshakeTimeout

Related to https://github.com/rancher/rancher/issues/21117