### PR TITLE
fixing yaml key to use snake case

### DIFF
--- a/generator/funcs.go
+++ b/generator/funcs.go
@@ -18,6 +18,7 @@ func funcs() template.FuncMap {
 		"hasGet":              hasGet,
 		"hasPost":             hasPost,
 		"getCollectionOutput": getCollectionOutput,
+		"toSnake":             convert.ToSnake,
 	}
 }
 

--- a/generator/type_template.go
+++ b/generator/type_template.go
@@ -21,7 +21,7 @@ type {{.schema.CodeName}} struct {
     types.Resource
 {{- end}}
     {{- range $key, $value := .structFields}}
-        {{$key}} {{$value.Type}} %BACK%json:"{{$value.Name}},omitempty" yaml:"{{$value.Name}},omitempty"%BACK%
+        {{$key}} {{$value.Type}} %BACK%json:"{{$value.Name}},omitempty" yaml:"{{toSnake $value.Name}},omitempty"%BACK%
     {{- end}}
 }
 

--- a/types/convert/convert.go
+++ b/types/convert/convert.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 	"unicode"
+
+	"github.com/iancoleman/strcase"
 )
 
 func Chan(c <-chan map[string]interface{}, f func(map[string]interface{}) map[string]interface{}) chan map[string]interface{} {
@@ -127,6 +129,10 @@ func ToFloat(value interface{}) (float64, error) {
 		return float64(f), err
 	}
 	return strconv.ParseFloat(ToString(value), 64)
+}
+
+func ToSnake(s string) string {
+	return strcase.ToSnake(s)
 }
 
 func Capitalize(s string) string {

--- a/vendor.conf
+++ b/vendor.conf
@@ -8,3 +8,4 @@ golang.org/x/sync                fd80eb99c8f653c847d294a001bdf2a3a6f768f5
 golang.org/x/tools               202502a5a9245830b5ec7b877e26b67760da8e67
 github.com/gorilla/mux           v1.6.1
 github.com/matryer/moq           ee5226d4300902ed04c84bde4837cb123d936feb https://github.com/rancher/moq
+github.com/iancoleman/strcase    e506e3ef73653e84c592ba44aab577a46678f68c

--- a/vendor/github.com/iancoleman/strcase/.travis.yml
+++ b/vendor/github.com/iancoleman/strcase/.travis.yml
@@ -1,0 +1,9 @@
+sudo: false
+language: go
+go:
+  - 1.1
+  - 1.2
+  - 1.3
+  - 1.4
+  - 1.5
+  - tip

--- a/vendor/github.com/iancoleman/strcase/LICENSE
+++ b/vendor/github.com/iancoleman/strcase/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Ian Coleman
+Copyright (c) 2018 Ma_124, <github.com/Ma124>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, Subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or Substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/iancoleman/strcase/README.md
+++ b/vendor/github.com/iancoleman/strcase/README.md
@@ -1,0 +1,24 @@
+# strcase
+[![Godoc Reference](https://godoc.org/github.com/iancoleman/strcase?status.svg)](http://godoc.org/github.com/iancoleman/strcase)
+[![Build Status](https://travis-ci.org/iancoleman/strcase.svg)](https://travis-ci.org/iancoleman/strcase)
+[![Coverage](http://gocover.io/_badge/github.com/iancoleman/strcase?0)](http://gocover.io/github.com/iancoleman/strcase)
+[![Go Report Card](https://goreportcard.com/badge/github.com/iancoleman/strcase)](https://goreportcard.com/report/github.com/iancoleman/strcase)
+
+strcase is a go package for converting string case to various cases (e.g. [snake case](https://en.wikipedia.org/wiki/Snake_case) or [camel case](https://en.wikipedia.org/wiki/CamelCase)) to see the full conversion table below.
+
+## Example
+
+```go
+s := "AnyKind of_string"
+```
+
+| Function                          | Result               |
+|-----------------------------------|----------------------|
+| `ToSnake(s)`                      | `any_kind_of_string` |
+| `ToScreamingSnake(s)`             | `ANY_KIND_OF_STRING` |
+| `ToKebab(s)`                      | `any-kind-of-string` |
+| `ToScreamingKebab(s)`             | `ANY-KIND-OF-STRING` |
+| `ToDelimited(s, '.')`             | `any.kind.of.string` |
+| `ToScreamingDelimited(s, '.')`    | `ANY.KIND.OF.STRING` |
+| `ToCamel(s)`                      | `AnyKindOfString`    |
+| `ToLowerCamel(s)`                 | `anyKindOfString`    |

--- a/vendor/github.com/iancoleman/strcase/camel.go
+++ b/vendor/github.com/iancoleman/strcase/camel.go
@@ -1,0 +1,75 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Ian Coleman
+ * Copyright (c) 2018 Ma_124, <github.com/Ma124>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, Subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or Substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package strcase
+
+import (
+	"strings"
+)
+
+// Converts a string to CamelCase
+func toCamelInitCase(s string, initCase bool) string {
+	s = addWordBoundariesToNumbers(s)
+	s = strings.Trim(s, " ")
+	n := ""
+	capNext := initCase
+	for _, v := range s {
+		if v >= 'A' && v <= 'Z' {
+			n += string(v)
+		}
+		if v >= '0' && v <= '9' {
+			n += string(v)
+		}
+		if v >= 'a' && v <= 'z' {
+			if capNext {
+				n += strings.ToUpper(string(v))
+			} else {
+				n += string(v)
+			}
+		}
+		if v == '_' || v == ' ' || v == '-' {
+			capNext = true
+		} else {
+			capNext = false
+		}
+	}
+	return n
+}
+
+// ToCamel converts a string to CamelCase
+func ToCamel(s string) string {
+	return toCamelInitCase(s, true)
+}
+
+// ToLowerCamel converts a string to lowerCamelCase
+func ToLowerCamel(s string) string {
+	if s == "" {
+		return s
+	}
+	if r := rune(s[0]); r >= 'A' && r <= 'Z' {
+		s = strings.ToLower(string(r)) + s[1:]
+	}
+	return toCamelInitCase(s, false)
+}

--- a/vendor/github.com/iancoleman/strcase/doc.go
+++ b/vendor/github.com/iancoleman/strcase/doc.go
@@ -1,0 +1,12 @@
+// Package strcase converts strings to various cases. See the conversion table below:
+//   | Function                        | Result             |
+//   |---------------------------------|--------------------|
+//   | ToSnake(s)                      | any_kind_of_string |
+//   | ToScreamingSnake(s)             | ANY_KIND_OF_STRING |
+//   | ToKebab(s)                      | any-kind-of-string |
+//   | ToScreamingKebab(s)             | ANY-KIND-OF-STRING |
+//   | ToDelimited(s, '.')             | any.kind.of.string |
+//   | ToScreamingDelimited(s, '.')    | ANY.KIND.OF.STRING |
+//   | ToCamel(s)                      | AnyKindOfString    |
+//   | ToLowerCamel(s)                 | anyKindOfString    |
+package strcase

--- a/vendor/github.com/iancoleman/strcase/numbers.go
+++ b/vendor/github.com/iancoleman/strcase/numbers.go
@@ -1,0 +1,38 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Ian Coleman
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, Subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or Substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package strcase
+
+import (
+	"regexp"
+)
+
+var numberSequence = regexp.MustCompile(`([a-zA-Z])(\d+)([a-zA-Z]?)`)
+var numberReplacement = []byte(`$1 $2 $3`)
+
+func addWordBoundariesToNumbers(s string) string {
+	b := []byte(s)
+	b = numberSequence.ReplaceAll(b, numberReplacement)
+	return string(b)
+}

--- a/vendor/github.com/iancoleman/strcase/snake.go
+++ b/vendor/github.com/iancoleman/strcase/snake.go
@@ -1,0 +1,93 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Ian Coleman
+ * Copyright (c) 2018 Ma_124, <github.com/Ma124>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, Subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or Substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package strcase
+
+import (
+	"strings"
+)
+
+// ToSnake converts a string to snake_case
+func ToSnake(s string) string {
+	return ToDelimited(s, '_')
+}
+
+// ToScreamingSnake converts a string to SCREAMING_SNAKE_CASE
+func ToScreamingSnake(s string) string {
+	return ToScreamingDelimited(s, '_', true)
+}
+
+// ToKebab converts a string to kebab-case
+func ToKebab(s string) string {
+	return ToDelimited(s, '-')
+}
+
+// ToScreamingKebab converts a string to SCREAMING-KEBAB-CASE
+func ToScreamingKebab(s string) string {
+	return ToScreamingDelimited(s, '-', true)
+}
+
+// ToDelimited converts a string to delimited.snake.case (in this case `del = '.'`)
+func ToDelimited(s string, del uint8) string {
+	return ToScreamingDelimited(s, del, false)
+}
+
+// ToScreamingDelimited converts a string to SCREAMING.DELIMITED.SNAKE.CASE (in this case `del = '.'; screaming = true`) or delimited.snake.case (in this case `del = '.'; screaming = false`)
+func ToScreamingDelimited(s string, del uint8, screaming bool) string {
+	s = addWordBoundariesToNumbers(s)
+	s = strings.Trim(s, " ")
+	n := ""
+	for i, v := range s {
+		// treat acronyms as words, eg for JSONData -> JSON is a whole word
+		nextCaseIsChanged := false
+		if i+1 < len(s) {
+			next := s[i+1]
+			if (v >= 'A' && v <= 'Z' && next >= 'a' && next <= 'z') || (v >= 'a' && v <= 'z' && next >= 'A' && next <= 'Z') {
+				nextCaseIsChanged = true
+			}
+		}
+
+		if i > 0 && n[len(n)-1] != del && nextCaseIsChanged {
+			// add underscore if next letter case type is changed
+			if v >= 'A' && v <= 'Z' {
+				n += string(del) + string(v)
+			} else if v >= 'a' && v <= 'z' {
+				n += string(v) + string(del)
+			}
+		} else if v == ' ' || v == '_' || v == '-' {
+			// replace spaces/underscores with delimiters
+			n += string(del)
+		} else {
+			n = n + string(v)
+		}
+	}
+
+	if screaming {
+		n = strings.ToUpper(n)
+	} else {
+		n = strings.ToLower(n)
+	}
+	return n
+}


### PR DESCRIPTION
Addresses: https://github.com/rancher/rancher/issues/15098

Problem: All the generated types have incorrect yaml keys in the tags.
Root cause: The generator is using the name directly instead of converting to snake case.
Fix: Change to snake case.