### PR TITLE
Pass delete options in proxy store

### DIFF
--- a/store/proxy/proxy_store_test.go
+++ b/store/proxy/proxy_store_test.go
@@ -1,0 +1,31 @@
+package proxy
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetDeletionOptions(t *testing.T) {
+	req, err := http.NewRequest("DELETE", "https://test.url/api", nil)
+	assert.Empty(t, err)
+	prop := metav1.DeletePropagationBackground
+	expected := &metav1.DeleteOptions{
+		PropagationPolicy: &prop,
+	}
+	options, err := getDeleteOption(req)
+	assert.Empty(t, err)
+	assert.Equal(t, options, expected, "unexpected deletion options for empty query")
+
+	req.URL.RawQuery = "gracePeriodSeconds=0"
+	period := int64(0)
+	expected = &metav1.DeleteOptions{
+		PropagationPolicy:  &prop,
+		GracePeriodSeconds: &period,
+	}
+	options, err = getDeleteOption(req)
+	assert.Empty(t, err)
+	assert.Equal(t, options, expected, "unexpected deletion options for query 'gracePeriodSeconds=0'")
+}


### PR DESCRIPTION
Address issue: https://github.com/rancher/rancher/issues/17823

Problem:
There is no way to pass gracePeriodSeconds for force deletion

Solution:
Get deletion options in query params and pass it in proxy store

More Infos:
1. In this solution, The APIs do force deletion by passing `gracePeriodSeconds=0`, which is the same way as apiserver. 
1. Kubernetes apiserver accepts delete options from entity-body of DELETE requests before v1.4, and support both query params and entity-body since v1.4. Because the usage of request body in DELETE request is kinda discouraged in HTTP/1.1 semantics and not supported by some clients. However, kubectl still pass deletion options to apiserver using request body. Refer to [this issue](https://github.com/kubernetes/kubernetes/issues/34856) for details.
2. This pr reuses ParameterCodec utilities which is how apiserver processes the deletion options, [see](https://github.com/kubernetes/kubernetes/blob/d08e68e75974eb31fd65422c969b352ed8397edc/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/delete.go#L93)
