### PR TITLE
Added IsForbidden function on clientbase

### DIFF
--- a/clientbase/common.go
+++ b/clientbase/common.go
@@ -92,6 +92,15 @@ func IsNotFound(err error) bool {
 	return apiError.StatusCode == http.StatusNotFound
 }
 
+func IsForbidden(err error) bool {
+	apiError, ok := err.(*APIError)
+	if !ok {
+		return false
+	}
+
+	return apiError.StatusCode == http.StatusForbidden
+}
+
 func NewAPIError(resp *http.Response, url string) *APIError {
 	contents, err := ioutil.ReadAll(resp.Body)
 	var body string


### PR DESCRIPTION
`IsForbidden(err)` function checks if the given APIError is a Forbidden HTTP statuscode

Related with issue https://github.com/terraform-providers/terraform-provider-rancher2/issues/50