### PR TITLE
Increase the wait latency of WebSocket ping

### DIFF
--- a/pkg/remotedialer/types.go
+++ b/pkg/remotedialer/types.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	PingWaitDuration  = time.Duration(10 * time.Second)
+	PingWaitDuration  = time.Duration(30 * time.Second)
 	PingWriteInterval = time.Duration(5 * time.Second)
 	MaxRead           = 8192
 )


### PR DESCRIPTION
**Problem:**
The read latency of WebSocket is too short for Windows agent, `10s` read
deadline might not enough for the peer to receive ping.

**Solution:**
Increase the wait duration of ping from 10s to 30s.

**Issue:**
https://github.com/rancher/rancher/issues/22543