### PR TITLE
Use original crd if already exists

### DIFF
--- a/store/crd/init.go
+++ b/store/crd/init.go
@@ -194,11 +194,11 @@ func (f *Factory) createCRD(apiClient clientset.Interface, schema *types.Schema,
 	}
 
 	logrus.Infof("Creating CRD %s", name)
-	crd, err := apiClient.ApiextensionsV1beta1().CustomResourceDefinitions().Create(crd)
+	crd2, err := apiClient.ApiextensionsV1beta1().CustomResourceDefinitions().Create(crd)
 	if errors.IsAlreadyExists(err) {
 		return crd, nil
 	}
-	return crd, err
+	return crd2, err
 }
 
 func (f *Factory) getReadyCRDs(apiClient clientset.Interface) (map[string]*apiext.CustomResourceDefinition, error) {


### PR DESCRIPTION
This PR fixes concurrent CRD creation.
Multiple Rancher replicas concurrently create CRDs. According to implementation, empty CRD struct will be used if CRD already exists, which cause Rancher panic (but succeed on next pod restart when all CRDs already created).

Empty structure generated in https://github.com/kubernetes/apiextensions-apiserver/blob/master/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/customresourcedefinition.go#L108
Original CRD struct should be used if AlreadyExists https://github.com/rancher/norman/blob/master/store/crd/init.go#L199
Panic happens here https://github.com/rancher/norman/blob/master/store/crd/init.go#L65 because of usage of empty CRD structure with uninitialized fields (crd.Name)

It doesn't break the whole deployment, but increase deployment time because of Rancher restart.