### PR TITLE
Switch duration to string to handle k8s metav1.duration

### DIFF
--- a/pkg/types/reflection.go
+++ b/pkg/types/reflection.go
@@ -537,6 +537,9 @@ func (s *Schemas) determineSchemaType(t reflect.Type) (string, error) {
 		if err != nil {
 			return "", err
 		}
+		if t.Name() == "Duration" && strings.Contains(schema.PkgName, "k8s.io/apimachinery/pkg/apis/meta/v1") {
+			return "string", nil
+		}
 		return schema.ID, nil
 	default:
 		return "", fmt.Errorf("unknown type kind %s", t.Kind())


### PR DESCRIPTION
See: https://github.com/kubernetes-sigs/controller-tools/pull/138

Avoiding just checking on `duration` because that could be `time.duration` which is not a string. 