### PR TITLE
Add ListNamespaced method for ObjectClient

### DIFF
--- a/generator/controller_template.go
+++ b/generator/controller_template.go
@@ -91,6 +91,7 @@ type {{.schema.CodeName}}Interface interface {
 	Delete(name string, options *metav1.DeleteOptions) error
 	DeleteNamespaced(namespace, name string, options *metav1.DeleteOptions) error
 	List(opts metav1.ListOptions) (*{{.schema.CodeName}}List, error)
+	ListNamespaced(namespace string, opts metav1.ListOptions) (*{{.schema.CodeName}}List, error)
 	Watch(opts metav1.ListOptions) (watch.Interface, error)
 	DeleteCollection(deleteOpts *metav1.DeleteOptions, listOpts metav1.ListOptions) error
 	Controller() {{.schema.CodeName}}Controller
@@ -276,6 +277,11 @@ func (s *{{.schema.ID}}Client) DeleteNamespaced(namespace, name string, options 
 
 func (s *{{.schema.ID}}Client) List(opts metav1.ListOptions) (*{{.schema.CodeName}}List, error) {
 	obj, err := s.objectClient.List(opts)
+	return obj.(*{{.schema.CodeName}}List), err
+}
+
+func (s *{{.schema.ID}}Client) ListNamespaced(namespace string, opts metav1.ListOptions) (*{{.schema.CodeName}}List, error) {
+	obj, err := s.objectClient.ListNamespaced(namespace, opts)
 	return obj.(*{{.schema.CodeName}}List), err
 }
 

--- a/objectclient/object_client.go
+++ b/objectclient/object_client.go
@@ -48,6 +48,7 @@ type GenericClient interface {
 	DeleteNamespaced(namespace, name string, opts *metav1.DeleteOptions) error
 	Delete(name string, opts *metav1.DeleteOptions) error
 	List(opts metav1.ListOptions) (runtime.Object, error)
+	ListNamespaced(namespace string, opts metav1.ListOptions) (runtime.Object, error)
 	Watch(opts metav1.ListOptions) (watch.Interface, error)
 	DeleteCollection(deleteOptions *metav1.DeleteOptions, listOptions metav1.ListOptions) error
 	Patch(name string, o runtime.Object, patchType types.PatchType, data []byte, subresources ...string) (runtime.Object, error)
@@ -222,6 +223,18 @@ func (p *ObjectClient) List(opts metav1.ListOptions) (runtime.Object, error) {
 	return result, p.restClient.Get().
 		Prefix(p.getAPIPrefix(), p.gvk.Group, p.gvk.Version).
 		NamespaceIfScoped(p.ns, p.resource.Namespaced).
+		Resource(p.resource.Name).
+		VersionedParams(&opts, metav1.ParameterCodec).
+		Do().
+		Into(result)
+}
+
+func (p *ObjectClient) ListNamespaced(namespace string, opts metav1.ListOptions) (runtime.Object, error) {
+	result := p.Factory.List()
+	logrus.Debugf("REST LIST %s/%s/%s/%s/%s", p.getAPIPrefix(), p.gvk.Group, p.gvk.Version, namespace, p.resource.Name)
+	return result, p.restClient.Get().
+		Prefix(p.getAPIPrefix(), p.gvk.Group, p.gvk.Version).
+		NamespaceIfScoped(namespace, p.resource.Namespaced).
 		Resource(p.resource.Name).
 		VersionedParams(&opts, metav1.ParameterCodec).
 		Do().


### PR DESCRIPTION
This PR will introduces ListNamespaced method for ObjectClient, that help to do namespaces list requests.
Related issue: https://github.com/rancher/rancher/issues/23934