### PR TITLE
change loglevel for watcher err

### DIFF
--- a/store/proxy/proxy_store.go
+++ b/store/proxy/proxy_store.go
@@ -317,7 +317,7 @@ func (s *Store) realWatch(apiContext *types.APIContext, schema *types.Schema, op
 		for event := range watcher.ResultChan() {
 			if data, ok := event.Object.(*metav1.Status); ok {
 				// just logging it, keeping the same behavior as before
-				logrus.Errorf("watcher error %s", data.Message)
+				logrus.Debugf("watcher status for %s: %s", schema.ID, data.Message)
 			} else {
 				data := event.Object.(*unstructured.Unstructured)
 				s.fromInternal(apiContext, schema, data.Object)


### PR DESCRIPTION
changing error level to debug, the error is already handled, new watcher gets started after the current one is closed. Closing is not done by rancher, it's a k8s behavior.

https://github.com/rancher/rancher/issues/23957