### PR TITLE
Add concurrency to list transform and format

### DIFF
--- a/api/writer/json.go
+++ b/api/writer/json.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"sync"
 
 	"github.com/rancher/norman/parse"
 	"github.com/rancher/norman/parse/builder"
@@ -57,14 +58,30 @@ func (j *EncodingResponseWriter) VersionBody(apiContext *types.APIContext, versi
 	return nil
 }
 func (j *EncodingResponseWriter) writeMapSlice(builder *builder.Builder, apiContext *types.APIContext, input []map[string]interface{}) *types.GenericCollection {
+	var (
+		convertWait   sync.WaitGroup
+		convertedList = make([]interface{}, len(input))
+	)
+
 	collection := newCollection(apiContext)
-	for _, value := range input {
-		converted := j.convert(builder, apiContext, value)
-		if converted != nil {
-			collection.Data = append(collection.Data, converted)
+	for index, value := range input {
+		// indexing converted values to maintain order
+		convertWait.Add(1)
+		go func(i int, val map[string]interface{}) {
+			converted := j.convert(builder, apiContext, val)
+			if converted != nil {
+				convertedList[i] = j.convert(builder, apiContext, val)
+			}
+			convertWait.Done()
+		}(index, value)
+	}
+	convertWait.Wait()
+
+	for _, val := range convertedList {
+		if val != nil {
+			collection.Data = append(collection.Data, val)
 		}
 	}
-
 	if apiContext.Schema.CollectionFormatter != nil {
 		apiContext.Schema.CollectionFormatter(apiContext, collection)
 	}
@@ -73,16 +90,32 @@ func (j *EncodingResponseWriter) writeMapSlice(builder *builder.Builder, apiCont
 }
 
 func (j *EncodingResponseWriter) writeInterfaceSlice(builder *builder.Builder, apiContext *types.APIContext, input []interface{}) *types.GenericCollection {
+	var (
+		convertWait   sync.WaitGroup
+		convertedList = make([]interface{}, len(input))
+	)
+
 	collection := newCollection(apiContext)
-	for _, value := range input {
-		switch v := value.(type) {
-		case map[string]interface{}:
-			converted := j.convert(builder, apiContext, v)
-			if converted != nil {
-				collection.Data = append(collection.Data, converted)
+	for index, value := range input {
+		convertWait.Add(1)
+		go func(i int, val interface{}) {
+			switch v := val.(type) {
+			case map[string]interface{}:
+				converted := j.convert(builder, apiContext, v)
+				if converted != nil {
+					convertedList[i] = j.convert(builder, apiContext, v)
+				}
+			default:
+				convertedList[i] = v
 			}
-		default:
-			collection.Data = append(collection.Data, v)
+			convertWait.Done()
+		}(index, value)
+	}
+	convertWait.Wait()
+
+	for _, val := range convertedList {
+		if val != nil {
+			collection.Data = append(collection.Data, val)
 		}
 	}
 


### PR DESCRIPTION
**Problem:**
Transform and format are synchronously performed on each element of a list. This
leads to noticeable slowness when working with larger numbers of elements.

**Solution:**
Add concurrency to transform store and format.

**Issue:**
https://github.com/rancher/rancher/issues/24931