### PR TITLE
k3s options update

### DIFF
--- a/pkg/kwrapper/k8s/k3s_linux.go
+++ b/pkg/kwrapper/k8s/k3s_linux.go
@@ -47,9 +47,10 @@ func k3sServer(ctx context.Context, endpoints []string) (string, error) {
 		"--no-deploy=traefik",
 		"--no-deploy=coredns",
 		"--no-deploy=servicelb",
+		"--no-deploy=metrics-server",
+		"--no-deploy=local-storage",
 		"--disable-agent",
-		fmt.Sprintf("--storage-endpoint=%s", strings.Join(endpoints, ",")),
-		"--storage-backend=etcd3")
+		fmt.Sprintf("--datastore-endpoint=%s", strings.Join(endpoints, ",")))
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Pdeathsig: syscall.SIGKILL,
 	}


### PR DESCRIPTION
**Problem**
Registration [options](https://rancher.com/docs/k3s/latest/en/installation/install-options/) have been update with the more recent k3s versions 

**Solution**
Update `--storage-endpoint` and `--storage-backend` to`--datastore-endpoint` 
https://rancher.com/docs/k3s/latest/en/installation/datastore/#datastore-endpoint-format-and-functionality

**Issue**
https://github.com/rancher/rancher/issues/24439