### PR TITLE
Update cluster_check to use interface if available

### DIFF
--- a/controller/cluster_check.go
+++ b/controller/cluster_check.go
@@ -1,12 +1,58 @@
 package controller
 
 import (
+	"os"
 	"reflect"
 	"strings"
+
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 )
 
+type ObjectClusterName interface {
+	ObjClusterName() string
+}
+
 func ObjectInCluster(cluster string, obj interface{}) bool {
+	// Check if the object implements the interface, this is best case and
+	// what objects should strive to be
+	if o, ok := obj.(ObjectClusterName); ok {
+		return o.ObjClusterName() == cluster
+	}
+
+	// For types outside of rancher, attempt to check the anno, then use the namespace
+	// This is much better than using the reflect hole below
+	switch v := obj.(type) {
+	case *corev1.Secret:
+		if c, ok := v.Annotations["field.cattle.io/projectId"]; ok {
+			if parts := strings.SplitN(c, ":", 2); len(parts) == 2 {
+				return cluster == parts[0]
+			}
+		}
+		return v.Namespace == cluster
+	case *corev1.Namespace:
+		if c, ok := v.Annotations["field.cattle.io/projectId"]; ok {
+			if parts := strings.SplitN(c, ":", 2); len(parts) == 2 {
+				return cluster == parts[0]
+			}
+		}
+		return v.Namespace == cluster
+	case *corev1.Node:
+		if c, ok := v.Annotations["field.cattle.io/projectId"]; ok {
+			if parts := strings.SplitN(c, ":", 2); len(parts) == 2 {
+				return cluster == parts[0]
+			}
+		}
+		return v.Namespace == cluster
+	}
+
+	// Seeing this message means something needs to be done with the type, see comments above
+	if dm := os.Getenv("CATTLE_DEV_MODE"); dm != "" {
+		logrus.Errorf("ObjectClusterName not implemented by type %T", obj)
+	}
+
 	var clusterName string
+
 	if c := getValue(obj, "ClusterName"); c.IsValid() {
 		clusterName = c.String()
 	}


### PR DESCRIPTION
Problem:
cluster_check relies on reflect which is slow and causes a large
performance hit which is especially noticable on restart

Solution:
Add a new interface ObjectClusterName that objects can implement so
reflect isn't used for that type