### PR TITLE
Drop resourceVersion on lists when set to 0

### DIFF
--- a/objectclient/object_client.go
+++ b/objectclient/object_client.go
@@ -221,6 +221,14 @@ func (p *ObjectClient) Delete(name string, opts *metav1.DeleteOptions) error {
 func (p *ObjectClient) List(opts metav1.ListOptions) (runtime.Object, error) {
 	result := p.Factory.List()
 	logrus.Tracef("REST LIST %s/%s/%s/%s/%s", p.getAPIPrefix(), p.gvk.Group, p.gvk.Version, p.ns, p.resource.Name)
+
+	// If ResourceVersion is set to 0 then the Limit is ignored on the API side. Usually
+	// that's not a problem, but with very large counts of a single object type the client will
+	// hit it's connection timeout
+	if opts.ResourceVersion == "0" {
+		opts.ResourceVersion = ""
+	}
+
 	return result, p.restClient.Get().
 		Prefix(p.getAPIPrefix(), p.gvk.Group, p.gvk.Version).
 		NamespaceIfScoped(p.ns, p.resource.Namespaced).
@@ -233,6 +241,11 @@ func (p *ObjectClient) List(opts metav1.ListOptions) (runtime.Object, error) {
 func (p *ObjectClient) ListNamespaced(namespace string, opts metav1.ListOptions) (runtime.Object, error) {
 	result := p.Factory.List()
 	logrus.Tracef("REST LIST %s/%s/%s/%s/%s", p.getAPIPrefix(), p.gvk.Group, p.gvk.Version, namespace, p.resource.Name)
+
+	if opts.ResourceVersion == "0" {
+		opts.ResourceVersion = ""
+	}
+
 	return result, p.restClient.Get().
 		Prefix(p.getAPIPrefix(), p.gvk.Group, p.gvk.Version).
 		NamespaceIfScoped(namespace, p.resource.Namespaced).


### PR DESCRIPTION
Problem:
In a cluster with a large number of a single object, say 10k large
secrets, when the controller starts it attempts to list all of those
secrets and hits the client timeout

Solution:
Just increasing the client timeout does not work as the API server also
has a timeout. The API server ignores the limit when resourceVersion is
set to 0 which causes the call to take longer than either timeout
(running curl against the API server the call was taking over 3min on
average and pulling approx 2GB of data) so if resourceVersion is set to
0 reset it to empty string

Issue: https://github.com/rancher/rancher/issues/26166