### PR TITLE
removing -l from goimports

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -478,7 +478,7 @@ func prepareDirs(dirs ...string) error {
 }
 
 func gofmt(workDir, pkg string) error {
-	cmd := exec.Command("goimports", "-w", "-l", "./"+pkg)
+	cmd := exec.Command("goimports", "-w", pkg)
 	fmt.Println(cmd.Args)
 	cmd.Dir = workDir
 	cmd.Stdout = os.Stdout


### PR DESCRIPTION
Per this recent change to goimports https://go-review.googlesource.com/c/tools/+/234484 `-l` now returns an exit code of 1 and generation will fail due to panic