### PR TITLE
Differentiate between empty and nil arrays

### DIFF
--- a/parse/builder/builder.go
+++ b/parse/builder/builder.go
@@ -447,6 +447,10 @@ func (b *Builder) convertArray(fieldType string, value interface{}, op Operation
 	}
 
 	var result []interface{}
+	if value == nil {
+		return result, nil
+	}
+	result = make([]interface{}, 0)
 	subType := definition.SubType(fieldType)
 
 	for _, value := range sliceValue {


### PR DESCRIPTION
Prior, empty array were converted to nil. In some cases the
difference between a nil and empty array are not arbitrary.
Now, empty arrays will be converted to empty interface arrays
and nil array will be converted to nil interface arrays.