### PR TITLE
Enable coredns in k3s

### DIFF
--- a/pkg/kwrapper/k8s/k3s_linux.go
+++ b/pkg/kwrapper/k8s/k3s_linux.go
@@ -44,7 +44,6 @@ func getEmbedded(ctx context.Context) (bool, clientcmd.ClientConfig, error) {
 func k3sServer(ctx context.Context, endpoints []string) (string, error) {
 	cmd := exec.Command("k3s", "server",
 		"--no-deploy=traefik",
-		"--no-deploy=coredns",
 		"--no-deploy=servicelb",
 		"--no-deploy=metrics-server",
 		"--no-deploy=local-storage",


### PR DESCRIPTION
Without this the pods inside the rancher run k3s cluster have no DNS server and fail to query any external DNS. 

Issue: https://github.com/rancher/rancher/issues/28279