### PR TITLE
feat(mapper): add custom domain fields for label and annotation mappers

### DIFF
--- a/types/mapper/annotation_field.go
+++ b/types/mapper/annotation_field.go
@@ -13,10 +13,14 @@ type AnnotationField struct {
 	Object           bool
 	List             bool
 	IgnoreDefinition bool
+	Domain           string
 }
 
 func (e AnnotationField) FromInternal(data map[string]interface{}) {
-	v, ok := values.RemoveValue(data, "annotations", "field.cattle.io/"+e.Field)
+	if len(e.Domain) == 0 {
+		e.Domain = "field.cattle.io"
+	}
+	v, ok := values.RemoveValue(data, "annotations", e.Domain+"/"+e.Field)
 	if ok {
 		if e.Object {
 			data := map[string]interface{}{}
@@ -37,6 +41,9 @@ func (e AnnotationField) FromInternal(data map[string]interface{}) {
 }
 
 func (e AnnotationField) ToInternal(data map[string]interface{}) error {
+	if len(e.Domain) == 0 {
+		e.Domain = "field.cattle.io"
+	}
 	v, ok := data[e.Field]
 	if ok {
 		if e.Object || e.List {
@@ -44,7 +51,7 @@ func (e AnnotationField) ToInternal(data map[string]interface{}) error {
 				v = string(bytes)
 			}
 		}
-		values.PutValue(data, convert.ToString(v), "annotations", "field.cattle.io/"+e.Field)
+		values.PutValue(data, convert.ToString(v), "annotations", e.Domain+"/"+e.Field)
 	}
 	values.RemoveValue(data, e.Field)
 	return nil

--- a/types/mapper/label_field.go
+++ b/types/mapper/label_field.go
@@ -6,20 +6,27 @@ import (
 )
 
 type LabelField struct {
-	Field string
+	Field  string
+	Domain string
 }
 
 func (e LabelField) FromInternal(data map[string]interface{}) {
-	v, ok := values.RemoveValue(data, "labels", "field.cattle.io/"+e.Field)
+	if len(e.Domain) == 0 {
+		e.Domain = "field.cattle.io"
+	}
+	v, ok := values.RemoveValue(data, "labels", e.Domain+"/"+e.Field)
 	if ok {
 		data[e.Field] = v
 	}
 }
 
 func (e LabelField) ToInternal(data map[string]interface{}) error {
+	if len(e.Domain) == 0 {
+		e.Domain = "field.cattle.io"
+	}
 	v, ok := data[e.Field]
 	if ok {
-		values.PutValue(data, v, "labels", "field.cattle.io/"+e.Field)
+		values.PutValue(data, v, "labels", e.Domain+"/"+e.Field)
 	}
 	return nil
 }


### PR DESCRIPTION
When I tried to use the "annotation" mapper, I found that I couldn't handle other domains. 
So set the default value and add a custom domain field