### PR TITLE
Adding impersonate-extra headers to request

### DIFF
--- a/store/proxy/proxy_store.go
+++ b/store/proxy/proxy_store.go
@@ -134,6 +134,14 @@ func (s *Store) doAuthed(apiContext *types.APIContext, request *rest.Request) re
 	for _, header := range authHeaders {
 		request.SetHeader(header, apiContext.Request.Header[http.CanonicalHeaderKey(header)]...)
 	}
+
+	//set extra info headers
+	for header := range apiContext.Request.Header {
+		if strings.HasPrefix(header, "Impersonate-Extra-") {
+			request.SetHeader(header, apiContext.Request.Header[http.CanonicalHeaderKey(header)]...)
+		}
+	}
+
 	return request.Do(apiContext.Request.Context())
 }
 


### PR DESCRIPTION
Rancher auth filter is now adding "Impersonate-Extra-" info headers that carry user's info from external identity provider, so we need to pass through those headers so that the info gets logged to k8s audit log.

Rancher PR: https://github.com/rancher/rancher/pull/31711

https://github.com/rancher/rancher/issues/31166