### PR TITLE
Add 'nullablestring' field type

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -81,6 +81,8 @@ func getTypeString(nullable bool, typeName string, schema *types.Schema, schemas
 		return "string"
 	case "hostname":
 		return "string"
+	case "nullablestring":
+		return "*string"
 	default:
 		if schema != nil && schemas != nil {
 			otherSchema := schemas.Schema(&schema.Version, typeName)

--- a/parse/builder/builder.go
+++ b/parse/builder/builder.go
@@ -382,6 +382,8 @@ func ConvertSimple(fieldType string, value interface{}, op Operation) (interface
 		return convert.ToString(value), nil
 	case "reference":
 		return convert.ToString(value), nil
+	case "nullablestring":
+		return convert.ToString(value), nil
 	}
 
 	return nil, ErrComplexType


### PR DESCRIPTION
Currently, *string fields in Go structs are converted to {type:
string, nullable: true} in the API schema, which is right, but then
converted down to just `string` when converted to generated client
structs. Without this patch, there is no way to express that *strings
should stay as *strings when run through the generator, because the
'nullable' flag is ignored. Compare this to *bools, which become
`boolean` in the schema and then correctly converted back to *bool in
the generator. This patch adds a backwards-compatible way to opt in to
converting *strings in the original struct to *strings in the generated
struct.

https://github.com/rancher/rancher/issues/30480
https://github.com/rancher/rancher/issues/32440