### PR TITLE
Log k3s server logs to file

### DIFF
--- a/pkg/kwrapper/k8s/k3s_linux.go
+++ b/pkg/kwrapper/k8s/k3s_linux.go
@@ -48,6 +48,7 @@ func k3sServer(ctx context.Context, endpoints []string) (string, error) {
 		"--no-deploy=metrics-server",
 		"--no-deploy=local-storage",
 		"--node-name=local-node",
+		"--log=./k3s.log",
 		fmt.Sprintf("--datastore-endpoint=%s", strings.Join(endpoints, ",")))
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Pdeathsig: syscall.SIGKILL,


### PR DESCRIPTION
This changes embbed k3s server log from os.stdout to file. K8s api-server log is quiet noisy and impact the ability to read rancher server log if combined together. 

https://github.com/rancher/rancher/issues/31859