### PR TITLE
Fix doSchema lock issue

### DIFF
--- a/types/schemas.go
+++ b/types/schemas.go
@@ -327,11 +327,9 @@ func (s *Schemas) doSchema(version *APIVersion, name string, lock bool) *Schema 
 
 	if lock {
 		s.Lock()
+		defer s.Unlock()
 	}
 	schemas, ok := s.schemasByPath[path]
-	if lock {
-		s.Unlock()
-	}
 	if !ok {
 		return nil
 	}


### PR DESCRIPTION
# Backgroud 
We sometimes faced the panic `fatal error: concurrent map read and map write` or `fatal error: concurrent map iteration and map write`.

# Investigation
we found the current lock is not enough:
```
	schemas, ok := s.schemasByPath[path]
```
this line seems wanted to copy but it's not copy because it's map.

and then, we have the possibility to face a panic like below

`concurrent map read and map write` :
```
	schema := schemas[name]
```

`concurrent map iteration and map write` :
```
	for _, check := range schemas {
```
# What is this PR
This PR fixes the above issue by extending lock to the end of this function.