### PR TITLE
Stop ignoring id fields for sub-schemas

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -106,7 +106,7 @@ func getTypeString(nullable bool, typeName string, pointer bool, schema *types.S
 func getTypeMap(schema *types.Schema, schemas *types.Schemas) map[string]fieldInfo {
 	result := map[string]fieldInfo{}
 	for name, field := range schema.ResourceFields {
-		if strings.EqualFold(name, "id") {
+		if strings.EqualFold(name, "id") && hasGet(schema) {
 			continue
 		}
 		result[field.CodeName] = fieldInfo{


### PR DESCRIPTION
When generating types, any field with name "id" was being skipped. The intention
here was to skip the "id" field of the embedded types.Resource struct. A type
will have an embedded types.Resource struct when the hasGet function returns
true. Therefore, this hasGet function is also used to skip the id fields as
desired.