### PR TITLE
Fix DeleteOption encoding errors for norman api

### DIFF
--- a/store/proxy/proxy_store.go
+++ b/store/proxy/proxy_store.go
@@ -544,7 +544,8 @@ func splitID(id string) (string, string) {
 
 func getDeleteOption(req *http.Request) (*metav1.DeleteOptions, error) {
 	options := &metav1.DeleteOptions{}
-	if err := metav1.ParameterCodec.DecodeParameters(req.URL.Query(), metav1.SchemeGroupVersion, options); err != nil {
+	values := req.URL.Query()
+	if err := metav1.Convert_url_Values_To_v1_DeleteOptions(&values, options, nil); err != nil {
 		return nil, err
 	}
 	prop := metav1.DeletePropagationBackground


### PR DESCRIPTION
refer to: https://github.com/rancher/rancher/issues/32847

There is no default converter for `DeleteOptions` in the latest(1.19+) SDK, we can use `Convert_url_Values_To_v1_DeleteOptions`.
https://github.com/kubernetes/kubernetes/issues/94688

If this can be merged, feel free to backport to v2.5.