### PR TITLE
Don't fail finalizer remove for nonexistent object

### DIFF
--- a/lifecycle/object.go
+++ b/lifecycle/object.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/rancher/norman/objectclient"
 	"github.com/rancher/norman/types/slice"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -141,6 +142,9 @@ func (o *objectLifecycleAdapter) removeFinalizer(name string, obj runtime.Object
 		}
 
 		obj, err = o.objectClient.GetNamespaced(metadata.GetNamespace(), metadata.GetName(), metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			return nil, nil
+		}
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
If the object doesn't exist, then some other worker must have already
removed its finalizers, so there is no need to requeue and try again.