### PR TITLE
Update Deprecated comment in controller template

### DIFF
--- a/generator/controller_template.go
+++ b/generator/controller_template.go
@@ -48,7 +48,7 @@ func init() {
 	resource.Put({{.schema.CodeName}}GroupVersionResource)
 }
 
-// Deprecated use {{.prefix}}{{.schema.CodeName}} instead
+// Deprecated: use {{.prefix}}{{.schema.CodeName}} instead
 type {{.schema.CodeName}} = {{.prefix}}{{.schema.CodeName}}
 
 func New{{.schema.CodeName}}(namespace, name string, obj {{.prefix}}{{.schema.CodeName}}) *{{.prefix}}{{.schema.CodeName}} {


### PR DESCRIPTION
Deprecated comments should begin with `"Deprecated:"` so it is recognized by modern linters.

https://github.com/golang/go/wiki/Deprecated