### PR TITLE
replace deprecated wait.Poll with wait.PollUntilContextTimeout

### DIFF
--- a/store/crd/init.go
+++ b/store/crd/init.go
@@ -135,7 +135,7 @@ func (f *Factory) waitCRD(ctx context.Context, apiClient clientset.Interface, cr
 	defer logrus.Infof("Done waiting for CRD %s to become available", crdName)
 
 	first := true
-	return wait.Poll(500*time.Millisecond, 60*time.Second, func() (bool, error) {
+	return wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 60*time.Second, false, func(ctx context.Context) (bool, error) {
 		if !first {
 			logrus.Infof("Waiting for CRD %s to become available", crdName)
 		}


### PR DESCRIPTION
related issue: https://github.com/rancher/rancher/issues/41840
to fix linting error: 
```
store/crd/init.go:138:9: SA1019: wait.Poll is deprecated: This method does not return errors from context, use PollWithContextTimeout. Note that the new method will no longer return ErrWaitTimeout and instead return errors defined by the context package. Will be removed in a future release. (staticcheck)
        return wait.Poll(500*time.Millisecond, 60*time.Second, func() (bool, error) {
               ^
             ```