### PR TITLE
Run go test in CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,7 +9,7 @@ platform:
 steps:
 - name: build
   pull: default
-  image: rancher/dapper:1.11.2
+  image: rancher/dapper:v0.6.0
   commands:
   - dapper ci
   privileged: true

--- a/scripts/ci
+++ b/scripts/ci
@@ -3,5 +3,6 @@ set -e
 
 cd $(dirname $0)
 
-./build
 ./validate
+./test
+./build


### PR DESCRIPTION
# Issue https://github.com/rancher/rancher/issues/44474

The test script is not running in the `ci` script. 

The changes:
- Run the test script in the ci script
- Move dapper image to `v0.6.0` as that is the latest image (2 years old). The 1.11.2 version is 7 years old [according to docker hub](https://hub.docker.com/r/rancher/dapper/tags?page=1&name=1.11.2).

I have dropped the following changes:
- The git command added allows users on linux to run dapper with DAPPER_MODE=bind which makes builds a bit faster by not requiring the repository to be copied, a bind mount can be used instead.
  - I'm not sure that's the proper way to fix this, need more investigation from me.
- Add volumes for caching go modules. This also makes the build faster.
  - This caching might work differently on GHA so instead of making it work both here and later, I'll defer to when we migrate to GHA.
- Run CI on arm64 in drone: Let's not add anything in drone unless necessary.