### PR TITLE
feat(controllertemplate): allow checking if kind is being cached

### DIFF
--- a/generator/controller_template.go
+++ b/generator/controller_template.go
@@ -89,6 +89,7 @@ type {{.schema.CodeName}}Controller interface {
 
 type {{.schema.CodeName}}Interface interface {
     ObjectClient() *objectclient.ObjectClient
+	IsCached() bool
 	Create(*{{.prefix}}{{.schema.CodeName}}) (*{{.prefix}}{{.schema.CodeName}}, error)
 	GetNamespaced(namespace, name string, opts metav1.GetOptions) (*{{.prefix}}{{.schema.CodeName}}, error)
 	Get(name string, opts metav1.GetOptions) (*{{.prefix}}{{.schema.CodeName}}, error)
@@ -244,6 +245,10 @@ type {{.schema.ID}}Client struct {
 
 func (s *{{.schema.ID}}Client) ObjectClient() *objectclient.ObjectClient {
 	return s.objectClient
+}
+
+func (s *{{.schema.ID}}Client) IsCached() bool {
+	return s.client.controllerFactory.SharedCacheFactory().IsCached({{.schema.CodeName}}GroupVersionKind)
 }
 
 func (s *{{.schema.ID}}Client) Create(o *{{.prefix}}{{.schema.CodeName}}) (*{{.prefix}}{{.schema.CodeName}}, error) {


### PR DESCRIPTION
### TO-DO

- [ ] Bump lasso once https://github.com/rancher/lasso/pull/69 is merged.

### Description

Extends the generated controller interface to allow checking if a cache already exists for that kind. There are cases that may benefit from using an existing cache but not worth to start it from scratch exclusively for those.

### Related

 - https://github.com/rancher/rancher/issues/41905