### PR TITLE
Removing release/v0.1 from renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,7 @@
     "github>rancher/renovate-config#release"
   ],
   "baseBranches": [
-    "main", "release/v0.4", "release/v0.3", "release/v0.2", "release/v0.1"
+    "main", "release/v0.4", "release/v0.3", "release/v0.2"
   ],
   "prHourlyLimit": 2
 }


### PR DESCRIPTION
- Remove release/v0.1 from renovate.json.