### PR TITLE
[v0.3] Backport memory leak

### DIFF
--- a/types/schemas.go
+++ b/types/schemas.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 	"sync"
 
@@ -83,6 +84,10 @@ func (s *Schemas) doRemoveSchema(schema Schema) *Schemas {
 	if schema.Embed {
 		s.removeEmbed(&schema)
 	}
+
+	s.schemas = slices.DeleteFunc(s.schemas, func(candidate *Schema) bool {
+		return candidate.ID == schema.ID
+	})
 
 	return s
 }

--- a/types/schemas_test.go
+++ b/types/schemas_test.go
@@ -1,0 +1,76 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSchemas(t *testing.T) {
+	version := APIVersion{
+		Group:   "meta.cattle.io",
+		Version: "v1",
+		Path:    "/shire",
+	}
+
+	s := NewSchemas().
+		AddSchema(Schema{
+			ID:                "baggins",
+			PluralName:        "bagginses",
+			Version:           version,
+			CollectionMethods: []string{},
+			ResourceMethods:   []string{},
+			ResourceFields:    map[string]Field{},
+		}).
+		AddSchema(Schema{
+			ID:                "hobbit",
+			PluralName:        "hobbits",
+			Embed:             true,
+			EmbedType:         "baggins",
+			Version:           version,
+			CollectionMethods: []string{},
+			ResourceMethods:   []string{},
+			ResourceFields: map[string]Field{
+				"breakfasts": {Type: "int"},
+				"name":       {Type: "string"},
+			},
+		})
+
+	expected := []*Schema{
+		{
+			ID:                "hobbit",
+			PluralName:        "hobbits",
+			Embed:             true,
+			EmbedType:         "baggins",
+			Version:           version,
+			CollectionMethods: []string{},
+			ResourceMethods:   []string{},
+			ResourceFields: map[string]Field{
+				"breakfasts": {Type: "int"},
+				"name":       {Type: "string"},
+			},
+			CodeName:       "Hobbit",
+			CodeNamePlural: "Hobbits",
+			BaseType:       "hobbit",
+			Type:           "/meta/schemas/schema",
+		},
+		{
+			ID:                "baggins",
+			PluralName:        "bagginses",
+			Version:           version,
+			CollectionMethods: []string{},
+			ResourceMethods:   []string{},
+			ResourceFields: map[string]Field{
+				"breakfasts": {Type: "int"},
+				"name":       {Type: "string"},
+			},
+			CodeName:       "Baggins",
+			CodeNamePlural: "Bagginses",
+			BaseType:       "baggins",
+			Type:           "/meta/schemas/schema",
+		},
+	}
+	actual := s.Schemas()
+
+	assert.ElementsMatch(t, expected, actual)
+}


### PR DESCRIPTION
backport https://github.com/rancher/norman/pull/523

> We neglect to remove schemas from s.schemas in s.doRemoveSchema which results in duplicate entries in s.schemas which are never removed. This introduces a memory leak of ~300 mb a week on a large rancher cluster.
>
> https://github.com/rancher/rancher/issues/47694