### PR TITLE
Add SameSite attribute to CSRF cookie

### DIFF
--- a/api/validate.go
+++ b/api/validate.go
@@ -59,11 +59,14 @@ func CheckCSRF(apiContext *types.APIContext) error {
 			return httperror.WrapAPIError(err, httperror.ServerError, "Failed in CSRF processing")
 		}
 
+		// SameSite=Lax (not Strict) so top-level cross-origin
+		// navigations (bookmarks, external links) still send the cookie.
 		cookie = &http.Cookie{
-			Name:   csrfCookie,
-			Value:  hex.EncodeToString(bytes),
-			Path:   "/",
-			Secure: true,
+			Name:     csrfCookie,
+			Value:    hex.EncodeToString(bytes),
+			Path:     "/",
+			Secure:   true,
+			SameSite: http.SameSiteLaxMode,
 		}
 
 		http.SetCookie(apiContext.Response, cookie)

--- a/api/validate_test.go
+++ b/api/validate_test.go
@@ -1,0 +1,26 @@
+package api_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/rancher/norman/api"
+	"github.com/rancher/norman/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckCSRF_IssuedCookieHasSameSiteLax(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "https://example.com/v3/things", nil)
+	req.Header.Set("User-Agent", "Mozilla/5.0 (compatible; test)")
+	rec := httptest.NewRecorder()
+	ctx := &types.APIContext{Method: http.MethodGet, Request: req, Response: rec}
+
+	require.NoError(t, api.CheckCSRF(ctx))
+
+	cookies := rec.Result().Cookies()
+	require.Len(t, cookies, 1)
+	assert.Equal(t, http.SameSiteLaxMode, cookies[0].SameSite)
+	assert.False(t, cookies[0].HttpOnly)
+}


### PR DESCRIPTION
Issue: SURE-10293
Github Issue : https://github.com/rancher/rancher/issues/54805

### Summary

- Adding SameSite field to all cookies since this is a good measure.