### PR TITLE
Tighten renovate rules to actually block Go-directive bumps on release branches

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -34,14 +34,16 @@
     },
     {
       "description": "Do not bump golang.org/x/tools minor/major on release branches - it tracks Go language releases and bumping it forces a go directive minor bump",
-      "matchPackageNames": ["golang.org/x/tools"],
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["/^golang\\.org\\/x\\/tools$/"],
       "matchUpdateTypes": ["major", "minor"],
       "matchBaseBranches": ["/^release\\//"],
       "enabled": false
     },
     {
       "description": "Do not bump the Go minor/major version on release branches",
-      "matchDepNames": ["go"],
+      "matchManagers": ["gomod"],
+      "matchDatasources": ["golang-version"],
       "matchUpdateTypes": ["major", "minor"],
       "matchBaseBranches": ["/^release\\//"],
       "enabled": false


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/44967

PR #826 added rules to prevent Go minor bumps on release branches, but PR #829 still slipped through (bumping `go 1.24.0` → `go 1.25.0` on `release/v0.7` as a side effect of `golang.org/x/tools` v0.43.0 requiring Go 1.25).

- **Go directive rule** used `matchDepNames: ["go"]`. Renovate models the Go directive as the `golang-version` datasource — `matchDepNames` doesn't catch it. Switched to `matchDatasources: ["golang-version"]`, which is what the rancher shared preset uses.
- **`golang.org/x/tools` rule** used a literal `matchPackageNames: ["golang.org/x/tools"]`. Switched to a regex (`/^golang\.org\/x\/tools$/`) and added `matchManagers: ["gomod"]` to be unambiguous.
