### PR TITLE
Block all golang.org/x/* minor bumps on release branches

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,7 @@
     "release/v0.5"
   ],
   "prHourlyLimit": 2,
+  "recreateWhen": "never",
   "enabledManagers": [
     "github-actions",
     "custom.regex",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -33,14 +33,6 @@
       "enabled": false
     },
     {
-      "description": "Do not bump golang.org/x/tools minor/major on release branches - it tracks Go language releases and bumping it forces a go directive minor bump",
-      "matchManagers": ["gomod"],
-      "matchPackageNames": ["/^golang\\.org\\/x\\/tools$/"],
-      "matchUpdateTypes": ["major", "minor"],
-      "matchBaseBranches": ["/^release\\//"],
-      "enabled": false
-    },
-    {
       "description": "Do not bump the Go minor/major version on release branches",
       "matchManagers": ["gomod"],
       "matchDatasources": ["golang-version"],
@@ -60,6 +52,14 @@
         "/^golang\\.org\\/x\\//"
       ],
       "groupName": "golang.org/x packages"
+    },
+    {
+      "description": "Do not bump golang.org/x/* minor/major on release branches - these packages track Go language releases and bumping them forces a go directive minor bump",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["/^golang\\.org\\/x\\//"],
+      "matchUpdateTypes": ["major", "minor"],
+      "matchBaseBranches": ["/^release\\//"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Broadens the renovate disable rule from just `golang.org/x/tools` to all `golang.org/x/*` packages on release branches — they all track Go releases and their minor bumps force a `go` directive bump (e.g. PR #831 bumped x/sync and x/text which dragged go 1.24→1.25)
- Moves the disable rule after the grouping rule so it takes precedence per Renovate's last-match-wins semantics
- Gets rid of "immortal" PRs for instances where we manually close one