### PR TITLE
fix: correct commenter regex and test YAMLEncoder rewrite

### DIFF
--- a/types/encoder.go
+++ b/types/encoder.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	commenter = regexp.MustCompile(`(?m)^( *)zzz#\\((.*)\\)\\((.*)\\)([a-z]+.*):(.*)`)
+	commenter = regexp.MustCompile(`(?m)^( *)zzz#\((.*)\)\((.*)\)([a-z]+.*):(.*)`)
 )
 
 func JSONEncoder(writer io.Writer, v interface{}) error {

--- a/types/encoder_test.go
+++ b/types/encoder_test.go
@@ -1,0 +1,23 @@
+package types
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TestYAMLEncoder verifies YAMLEncoder's own behavior: it rewrites builder.go's
+// default markers ("zzz#(desc)(type)name" keys) into YAML comments, and it
+// propagates marshal errors.
+func TestYAMLEncoder(t *testing.T) {
+	var buf bytes.Buffer
+	if err := YAMLEncoder(&buf, map[string]string{"zzz#(a description)(string)fieldName": "somevalue"}); err != nil {
+		t.Fatalf("YAMLEncoder() error = %v", err)
+	}
+	if got, want := buf.String(), "# fieldName: somevalue\n"; got != want {
+		t.Errorf("YAMLEncoder() = %q, want %q", got, want)
+	}
+
+	if err := YAMLEncoder(&bytes.Buffer{}, func() {}); err == nil {
+		t.Error("YAMLEncoder() expected error for unmarshalable value, got nil")
+	}
+}


### PR DESCRIPTION
Adds missing unit tests for the migrated YAML marshalling paths.